### PR TITLE
feat: add mermaid diagram support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ bundle install
 bundle exec jekyll serve
 # open http://127.0.0.1:4000
 ```
+
+## Mermaid diagrams
+
+Mermaid diagrams are supported. Include them in Markdown using fenced code blocks:
+
+````markdown
+```mermaid
+sequenceDiagram
+    Alice->>Bob: Hello Bob
+```
+````
+

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,1 @@
+<script src="https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js"></script>

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,1 +1,5 @@
-/* (paste the custom.js from above) */
+document.addEventListener('DOMContentLoaded', () => {
+  if (window.mermaid) {
+    mermaid.initialize({ startOnLoad: true });
+  }
+});


### PR DESCRIPTION
## Summary
- load mermaid.js globally via head include
- init mermaid on DOM ready for automatic diagram rendering
- document mermaid usage in README

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a8bbebdc14832d9f9e82318fc35eab